### PR TITLE
[playtron-os-scripts] Add 'parted' as a dependency

### DIFF
--- a/playtron-os-scripts/playtron-os-scripts.spec
+++ b/playtron-os-scripts/playtron-os-scripts.spec
@@ -6,7 +6,7 @@ License: Apache-2.0
 URL: https://github.com/playtron-os/playtron-os-scripts
 Source0: https://github.com/playtron-os/playtron-os-scripts/archive/refs/tags/%{version}.tar.gz
 BuildArch: noarch
-Requires: cloud-utils-growpart fio
+Requires: cloud-utils-growpart fio parted
 
 %description
 %{summary}.


### PR DESCRIPTION
Since the Playtron OS build no longer installs
recommended/weak/optional dependencies, 'parted' is no longer installed which is required for drive formatting.