### PR TITLE
Update workflows to Fedora 40

### DIFF
--- a/.github/workflows/gamescope-session-playtron.yml
+++ b/.github/workflows/gamescope-session-playtron.yml
@@ -15,7 +15,7 @@ jobs:
     name: Test gamescope-session-playtron RPM build
     runs-on: ubuntu-22.04
     container:
-      image: fedora:38
+      image: fedora:40
     steps:
       - uses: actions/checkout@v3
       - name: Install RPM build dependencies

--- a/.github/workflows/gamescope-session.yml
+++ b/.github/workflows/gamescope-session.yml
@@ -11,7 +11,7 @@ jobs:
     name: Test gamescope-session RPM build
     runs-on: ubuntu-22.04
     container:
-      image: fedora:38
+      image: fedora:40
     steps:
       - uses: actions/checkout@v3
       - name: Install RPM build dependencies

--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -28,13 +28,13 @@ jobs:
       - name: Change directory
         run: cd $GITHUB_WORKSPACE
       - name: Create a container
-        run: docker run -d -v $(pwd):/root --name fedora38 fedora:38 sleep infinity
+        run: docker run -d -v $(pwd):/root --name fedora40 fedora:40 sleep infinity
       # The Linux kernel is currently handled via a script.
       # When we get to the point where we need to add custom patches,
       # we will add it as an additional directory similar to the existing RPMs.
       - name: Build the Linux kernel source RPM
-        run: docker exec fedora38 /root/kernel.sh
+        run: docker exec fedora40 /root/kernel.sh
       - name: Build the Linux kernel binary RPMs
-        run: docker exec fedora38 rpmbuild -bb /root/kernel/kernel.spec
+        run: docker exec fedora40 rpmbuild -bb /root/kernel/kernel.spec
       - name: Install RPMs
-        run: docker exec fedora38 dnf -y install /root/rpmbuild/RPMS/*/*.rpm
+        run: docker exec fedora40 dnf -y install /root/rpmbuild/RPMS/*/*.rpm

--- a/.github/workflows/mesa.yml
+++ b/.github/workflows/mesa.yml
@@ -11,7 +11,7 @@ jobs:
     name: Test mesa RPM build
     runs-on: ubuntu-22.04
     container:
-      image: fedora:39
+      image: fedora:40
     steps:
       - uses: actions/checkout@v3
       - name: Install RPM build dependencies

--- a/.github/workflows/playtron-os-files.yml
+++ b/.github/workflows/playtron-os-files.yml
@@ -11,7 +11,7 @@ jobs:
     name: Test playtron-os-files RPM build
     runs-on: ubuntu-22.04
     container:
-      image: fedora:38
+      image: fedora:40
     steps:
       - uses: actions/checkout@v3
       - name: Install RPM build dependencies

--- a/.github/workflows/python3-edl.yml
+++ b/.github/workflows/python3-edl.yml
@@ -11,7 +11,7 @@ jobs:
     name: Test python3-edl RPM build
     runs-on: ubuntu-22.04
     container:
-      image: fedora:38
+      image: fedora:40
     steps:
       - uses: actions/checkout@v3
       - name: Install RPM build dependencies

--- a/.github/workflows/udev-media-automount.yml
+++ b/.github/workflows/udev-media-automount.yml
@@ -11,7 +11,7 @@ jobs:
     name: Test udev-media-automount RPM build
     runs-on: ubuntu-22.04
     container:
-      image: fedora:38
+      image: fedora:40
     steps:
       - uses: actions/checkout@v3
       - name: Install RPM build dependencies


### PR DESCRIPTION
For binary RPM builds, use Fedora 40. Continue to use Fedora 38 (or Fedora 39 for Mesa) as the minimum version to build source RPMs for Fedora Copr. Source RPMs are not backwards compatible but are forward compatible.