### PR TITLE
[github_actions] Allow manual uploads

### DIFF
--- a/.github/workflows/gamescope-session-playtron-upload.yml
+++ b/.github/workflows/gamescope-session-playtron-upload.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'gamescope-session-playtron/**'
+  workflow_dispatch:
 
 env:
   PACKAGE_NAME: gamescope-session-playtron

--- a/.github/workflows/gamescope-session-upload.yml
+++ b/.github/workflows/gamescope-session-upload.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'gamescope-session/**'
+  workflow_dispatch:
 jobs:
   upload:
     name: Upload gamescope-session source RPM to Fedora Copr

--- a/.github/workflows/kernel-upload.yml
+++ b/.github/workflows/kernel-upload.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - kernel.sh
+  workflow_dispatch:
 jobs:
   upload:
     name: Upload kernel source RPM to Fedora Copr

--- a/.github/workflows/mangohud-upload.yml
+++ b/.github/workflows/mangohud-upload.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'mangohud/**'
+  workflow_dispatch:
 jobs:
   upload:
     name: Upload mangohud source RPM to Fedora Copr

--- a/.github/workflows/mesa-upload.yml
+++ b/.github/workflows/mesa-upload.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'mesa/**'
+  workflow_dispatch:
 jobs:
   upload:
     name: Upload mesa source RPM to Fedora Copr

--- a/.github/workflows/playtron-os-files-upload.yml
+++ b/.github/workflows/playtron-os-files-upload.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'playtron-os-files/**'
+  workflow_dispatch:
 jobs:
   upload:
     name: Upload playtron-os-files source RPM to Fedora Copr

--- a/.github/workflows/python3-edl-upload.yml
+++ b/.github/workflows/python3-edl-upload.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'python3-edl/**'
+  workflow_dispatch:
 jobs:
   upload:
     name: Upload python3-edl source RPM to Fedora Copr

--- a/.github/workflows/reaper-upload.yml
+++ b/.github/workflows/reaper-upload.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'reaper/**'
+  workflow_dispatch:
 jobs:
   upload:
     name: Upload reaper source RPM to Fedora Copr

--- a/.github/workflows/udev-media-automount-upload.yml
+++ b/.github/workflows/udev-media-automount-upload.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'udev-media-automount/**'
+  workflow_dispatch:
 jobs:
   upload:
     name: Upload udev-media-automount source RPM to Fedora Copr

--- a/.github/workflows/valve-firmware-upload.yml
+++ b/.github/workflows/valve-firmware-upload.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'valve-firmware/**'
+  workflow_dispatch:
 jobs:
   upload:
     name: Upload valve-firmware source RPM to Fedora Copr


### PR DESCRIPTION
This is useful for the scenario when the Fedora Copr API key is expired.