### PR TITLE
[valve-firmware] Only build for x86_64

### DIFF
--- a/.github/workflows/valve-firmware-upload.yml
+++ b/.github/workflows/valve-firmware-upload.yml
@@ -40,4 +40,4 @@ jobs:
           copr_url = https://copr.fedorainfracloud.org
           EOF
       - name: Upload the source RPM to Fedora Copr
-        run: copr-cli build gaming ~/rpmbuild/SRPMS/valve-firmware-*.src.rpm
+        run: copr-cli build --exclude-chroot fedora-39-aarch64 --exclude-chroot fedora-40-aarch64 --exclude-chroot fedora-39-i386 --exclude-chroot fedora-40-i386 gaming ~/rpmbuild/SRPMS/valve-firmware-*.src.rpm


### PR DESCRIPTION
on the Fedora Copr. Do not build 32-bit x86 packages or 64-bit Arm packages. This firmware only works on 64-bit x86.