### PR TITLE
OS-39 fix benchmarks failing to run due to missing dependency

### DIFF
--- a/playtron-os-files/playtron-os-files.spec
+++ b/playtron-os-files/playtron-os-files.spec
@@ -6,7 +6,7 @@ License: Apache-2.0
 URL: https://github.com/playtron-os/playtron-os-files
 Source0: https://github.com/playtron-os/playtron-os-files/archive/refs/tags/%{version}.tar.gz
 BuildArch: noarch
-Requires: clatd cloud-utils-growpart fio parted
+Requires: clatd cloud-utils-growpart fio fio-engine-libaio parted
 BuildRequires: systemd-rpm-macros
 Obsoletes: playtron-os-scripts <= 0.5.1-1
 Conflicts: playtron-os-scripts


### PR DESCRIPTION
Note: Will create a follow up PR to bump the package version.