### PR TITLE
Update mangohud version

### DIFF
--- a/mangohud/mangohud.spec
+++ b/mangohud/mangohud.spec
@@ -30,7 +30,7 @@
 %endif
 
 Name:           mangohud
-Version:        0.7.1
+Version:        0.7.2
 %forgemeta
 Release:        %autorelease
 Summary:        Vulkan and OpenGL overlay for monitoring FPS, temperatures, CPU/GPU load


### PR DESCRIPTION
On Nobara 41, our mangohud fork is masked by mangohud 0.7.2 packages. I'm not 100% sure just bumping the version number in the spec file is enough so let me know if anything else is needed.

Also, should we consider sending our patch for increased logging upstream? That would free us from maintaining a fork