### PR TITLE
[WIP][valve-firmware] Use Steam Deck OLED specific profile

### DIFF
--- a/valve-firmware/pipewire-pulse.conf
+++ b/valve-firmware/pipewire-pulse.conf
@@ -1,0 +1,183 @@
+# PulseAudio config file for PipeWire version "1.2.7" #
+#
+# Copy and edit this file in /etc/pipewire for system-wide changes
+# or in ~/.config/pipewire for local changes.
+#
+# It is also possible to place a file with an updated section in
+# /etc/pipewire/pipewire-pulse.conf.d/ for system-wide changes or in
+# ~/.config/pipewire/pipewire-pulse.conf.d/ for local changes.
+#
+
+context.properties = {
+    ## Configure properties in the system.
+    #mem.warn-mlock  = false
+    #mem.allow-mlock = true
+    #mem.mlock-all   = false
+    #log.level       = 2
+
+    #default.clock.quantum-limit = 8192
+}
+
+context.spa-libs = {
+    audio.convert.* = audioconvert/libspa-audioconvert
+    support.*       = support/libspa-support
+}
+
+context.modules = [
+    { name = libpipewire-module-rt
+        args = {
+            nice.level   = -11
+            #rt.prio      = 55
+            #rt.time.soft = -1
+            #rt.time.hard = -1
+            #uclamp.min = 0
+            #uclamp.max = 1024
+        }
+        flags = [ ifexists nofail ]
+    }
+    { name = libpipewire-module-protocol-native }
+    { name = libpipewire-module-client-node }
+    { name = libpipewire-module-adapter }
+    { name = libpipewire-module-metadata }
+
+    { name = libpipewire-module-protocol-pulse
+        args = {
+	    # contents of pulse.properties can also be placed here
+	    # to have config per server.
+        }
+    }
+]
+
+# Extra scripts can be started here. Setup in default.pa can be moved in
+# a script or in pulse.cmd below
+context.exec = [
+    #{ path = "pactl"        args = "load-module module-always-sink" }
+    #{ path = "pactl"        args = "upload-sample my-sample.wav my-sample" }
+    #{ path = "/usr/bin/sh"  args = "~/.config/pipewire/default.pw" }
+]
+
+# Extra commands can be executed here.
+#   load-module : loads a module with args and flags
+#      args = "<module-name> <module-args>"
+#      ( flags = [ nofail ] )
+pulse.cmd = [
+    { cmd = "load-module" args = "module-always-sink" flags = [ ] }
+    { cmd = "load-module" args = "module-device-manager" flags = [ ] }
+    { cmd = "load-module" args = "module-device-restore" flags = [ ] }
+    { cmd = "load-module" args = "module-stream-restore" flags = [ ] }
+    #{ cmd = "load-module" args = "module-switch-on-connect" }
+    #{ cmd = "load-module" args = "module-gsettings" flags = [ nofail ] }
+]
+
+stream.properties = {
+    #node.latency          = 1024/48000
+    #node.autoconnect      = true
+    #resample.quality      = 4
+    #channelmix.normalize  = false
+    #channelmix.mix-lfe    = true
+    #channelmix.upmix      = true
+    #channelmix.upmix-method = psd  # none, simple
+    #channelmix.lfe-cutoff = 150
+    #channelmix.fc-cutoff  = 12000
+    #channelmix.rear-delay = 12.0
+    #channelmix.stereo-widen = 0.0
+    #channelmix.hilbert-taps = 0
+    #dither.noise = 0
+}
+
+pulse.properties = {
+    # the addresses this server listens on
+    server.address = [
+        "unix:native"
+        #"unix:/tmp/something"              # absolute paths may be used
+        #"tcp:4713"                         # IPv4 and IPv6 on all addresses
+        #"tcp:[::]:9999"                    # IPv6 on all addresses
+        #"tcp:127.0.0.1:8888"               # IPv4 on a single address
+        #
+        #{ address = "tcp:4713"             # address
+        #  max-clients = 64                 # maximum number of clients
+        #  listen-backlog = 32              # backlog in the server listen queue
+        #  client.access = "restricted"     # permissions for clients
+        #}
+    ]
+    #server.dbus-name       = "org.pulseaudio.Server"
+    #pulse.allow-module-loading = true
+    #pulse.min.req          = 128/48000     # 2.7ms
+    pulse.min.req          = 1024/48000 
+    #pulse.default.req      = 960/48000     # 20 milliseconds
+    #pulse.min.frag         = 128/48000     # 2.7ms
+    pulse.min.frag         = 1024/48000
+    #pulse.default.frag     = 96000/48000   # 2 seconds
+    #pulse.default.tlength  = 96000/48000   # 2 seconds
+    #pulse.min.quantum      = 128/48000     # 2.7ms
+    pulse.min.quantum      = 1024/48000
+    #pulse.idle.timeout     = 0             # don't pause after underruns
+    #pulse.default.format   = F32
+    #pulse.default.position = [ FL FR ]
+}
+
+pulse.properties.rules = [
+    {   matches = [ { cpu.vm.name = !null } ]
+        actions = {
+            update-props = {
+            # These overrides are only applied when running in a vm.
+                pulse.min.quantum = 1024/48000      # 22ms
+	    }
+        }
+    }
+]
+
+# client/stream specific properties
+pulse.rules = [
+    {
+        matches = [
+            {
+                # all keys must match the value. ! negates. ~ starts regex.
+                #client.name                = "Firefox"
+                #application.process.binary = "teams"
+                #application.name           = "~speech-dispatcher.*"
+            }
+        ]
+        actions = {
+            update-props = {
+                #node.latency = 512/48000
+            }
+            # Possible quirks:"
+            #    force-s16-info                 forces sink and source info as S16 format
+            #    remove-capture-dont-move       removes the capture DONT_MOVE flag
+            #    block-source-volume            blocks updates to source volume
+            #    block-sink-volume              blocks updates to sink volume
+            #quirks = [ ]
+        }
+    }
+    {
+        # skype does not want to use devices that don't have an S16 sample format.
+        matches = [
+             { application.process.binary = "teams" }
+             { application.process.binary = "teams-insiders" }
+             { application.process.binary = "skypeforlinux" }
+        ]
+        actions = { quirks = [ force-s16-info ] }
+    }
+    {
+        # firefox marks the capture streams as don't move and then they
+        # can't be moved with pavucontrol or other tools.
+        matches = [ { application.process.binary = "firefox" } ]
+        actions = { quirks = [ remove-capture-dont-move ] }
+    }
+    {
+        # speech dispatcher asks for too small latency and then underruns.
+        matches = [ { application.name = "~speech-dispatcher.*" } ]
+        actions = {
+            update-props = {
+                pulse.min.req          = 512/48000      # 10.6ms
+                pulse.min.quantum      = 512/48000      # 10.6ms
+                pulse.idle.timeout     = 5              # pause after 5 seconds of underrun
+            }
+        }
+    }
+    #{
+    #    matches = [ { application.process.binary = "Discord" } ]
+    #    actions = { quirks = [ block-source-volume ] }
+    #}
+]

--- a/valve-firmware/valve-firmware.spec
+++ b/valve-firmware/valve-firmware.spec
@@ -1,7 +1,7 @@
 Name: valve-firmware
 # There are two source packages that use a date version. Set the RPM version to mirror whichever source is newer.
 Version: 20240917.1
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Linux firmware files for the Steam Deck OLED
 License: GPL+ and GPLv2+ and MIT and Redistributable, no modification permitted
 URL: https://steamdeck-packages.steamos.cloud/archlinux-mirror/jupiter-main/os/x86_64/
@@ -48,6 +48,8 @@ mv usr/lib/firmware/cs35l41-dsp1-spk-{cali.bin,cali.wmfw}.xz %{buildroot}/%{_pre
 tar -xvf %{_sourcedir}/steamdeck-dsp-0.49.5-1-any.pkg.tar.zst -C %{buildroot}/
 rm -f %{buildroot}/.BUILDINFO %{buildroot}/.MTREE %{buildroot}/.PKGINFO %{buildroot}/etc/wireplumber
 
+cp %{_sourcedir}/pipewire-pulse.conf %{buildroot}%{_prefix}/share/pipewire/hardware-profiles/valve-jupiter/pipewire.conf.d/
+
 %files
 %{_prefix}/lib/firmware/ath11k/QCA206X/hw2.1/amss.bin.xz
 %{_prefix}/lib/firmware/ath11k/QCA206X/hw2.1/board-2.bin.xz
@@ -87,6 +89,7 @@ rm -f %{buildroot}/.BUILDINFO %{buildroot}/.MTREE %{buildroot}/.PKGINFO %{buildr
 %{_prefix}/share/pipewire/hardware-profiles/valve-galileo/pipewire.conf.d/virtual-sink.conf
 %{_prefix}/share/pipewire/hardware-profiles/valve-galileo/pipewire.conf.d/virtual-source.conf
 %{_prefix}/share/pipewire/hardware-profiles/valve-jupiter/pipewire.conf.d/filter-chain.conf
+%{_prefix}/share/pipewire/hardware-profiles/valve-jupiter/pipewire.conf.d/pipewire-pulse.conf
 %{_prefix}/share/pipewire/hardware-profiles/valve-jupiter/pipewire.conf.d/virtual-source.conf
 %{_prefix}/share/wireplumber/hardware-profiles/default
 %{_prefix}/share/wireplumber/hardware-profiles/valve-galileo/wireplumber.conf.d/alsa-card0.conf
@@ -102,6 +105,9 @@ rm -f %{buildroot}/.BUILDINFO %{buildroot}/.MTREE %{buildroot}/.PKGINFO %{buildr
 %{_prefix}/share/wireplumber/hardware-profiles/wireplumber-hwconfig
 
 %changelog
+* Wed Feb 05 2025 Luke Short <ekultails@gmail.com> 20240917.1-3
+- Add Steam Deck OLED specific configuration with a faster polling rate to fix crackling audio issues
+
 * Wed Feb 05 2025 Luke Short <ekultails@gmail.com> 20240917.1-2
 - Conflict with Nobara packages
 


### PR DESCRIPTION
This PR currently does NOT work. What we need is to use a PipeWire configuration for PulseAudio compatibility with these settings for ``pipewire-pulse.conf`` below for a faster polling rate. Otherwise, there is crackling audio in all games using Proton. Interestingly, the Playtron/Grid app is unaffected. That workaround with user configuration files DOES work. We may need to work on the `os-device-quirks` we've been talking about to implement this.

```
pulse.properties = {
    # the addresses this server listens on
    server.address = [
        "unix:native"
        #"unix:/tmp/something"              # absolute paths may be used
        #"tcp:4713"                         # IPv4 and IPv6 on all addresses
        #"tcp:[::]:9999"                    # IPv6 on all addresses
        #"tcp:127.0.0.1:8888"               # IPv4 on a single address
        #
        #{ address = "tcp:4713"             # address
        #  max-clients = 64                 # maximum number of clients
        #  listen-backlog = 32              # backlog in the server listen queue
        #  client.access = "restricted"     # permissions for clients
        #}
    ]
    #server.dbus-name       = "org.pulseaudio.Server"
    #pulse.allow-module-loading = true
    #pulse.min.req          = 128/48000     # 2.7ms
    pulse.min.req          = 1024/48000 
    #pulse.default.req      = 960/48000     # 20 milliseconds
    #pulse.min.frag         = 128/48000     # 2.7ms
    pulse.min.frag         = 1024/48000
    #pulse.default.frag     = 96000/48000   # 2 seconds
    #pulse.default.tlength  = 96000/48000   # 2 seconds
    #pulse.min.quantum      = 128/48000     # 2.7ms
    pulse.min.quantum      = 1024/48000
    #pulse.idle.timeout     = 0             # don't pause after underruns
    #pulse.default.format   = F32
    #pulse.default.position = [ FL FR ]
}
```

I can't take credit for the fix. I found it from this GitHub Issue: https://github.com/moonlight-stream/moonlight-qt/issues/1184#top (thanks @liadala !).

```
on windows using virtual audio sinks might help

on linux

Create a new folder for the Pipewire config settings, move the config settings there, and set permissions
mkdir ~/.config/pipewire

cp /usr/share/pipewire/*.conf ~/.config/pipewire

chown $USER ~/.config/pipewire/pipewire-pulse.conf
Edit the pulse-properties.conf file
nano ~/.config/pipewire/pipewire-pulse.conf
Find the pulse properties section, uncomment the following keys, and set their values to either 512 or 1024
pulse.min.req = 1024/48000

pulse.min.frag = 1024/48000

pulse.min.quantum = 1024/48000
Reboot
```