### PR TITLE
[github_actions] Add repositories

### DIFF
--- a/.github/workflows/playtron-os-files.yml
+++ b/.github/workflows/playtron-os-files.yml
@@ -24,6 +24,20 @@ jobs:
         run: spectool -g -R ${GITHUB_WORKSPACE}/playtron-os-files/*.spec
       - name: Build the source RPM
         run: rpmbuild -bs ${GITHUB_WORKSPACE}/playtron-os-files/*.spec
+      - name: Enable the Playtron App repository to install powerstation
+        run: |
+          cat <<EOF > /etc/yum.repos.d/playtron-app-x86_64.repo
+          [playtron-app-x86_64]
+          name=Playtron Labs and App repository
+          baseurl=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/repos/playtron-app/x86_64/
+          type=rpm-md
+          skip_if_unavailable=False
+          gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-playtronos
+          gpgcheck=0
+          repo_gpgcheck=0
+          enabled=1
+          enabled_metadata=1
+          EOF
       - name: Install the DNF build dependencies plugin
         run: dnf -y install 'dnf-command(builddep)'
       - name: Install the required build dependencies.

--- a/playtron-os-files/playtron-os-files.spec
+++ b/playtron-os-files/playtron-os-files.spec
@@ -1,12 +1,12 @@
 Name: playtron-os-files
 Version: 0.19.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Scripts and services for a gaming OS
 License: GPL-3.0-only
 URL: https://github.com/playtron-os/playtron-os-files
 Source0: https://github.com/playtron-os/playtron-os-files/archive/refs/tags/%{version}.tar.gz
 BuildArch: noarch
-Requires: clatd cloud-utils-growpart fio fio-engine-libaio parted python3-pygame foot google-noto-sans-mono-cjk-vf-fonts stress-ng vkmark alsa-utils ffmpeg powerstation upower
+Requires: clatd cloud-utils-growpart fio fio-engine-libaio parted python3-pygame foot google-noto-sans-mono-cjk-vf-fonts stress-ng vkmark alsa-utils /usr/bin/ffmpeg powerstation upower
 BuildRequires: systemd-rpm-macros
 Obsoletes: playtron-os-scripts <= 0.5.1-1
 Conflicts: playtron-os-scripts
@@ -93,6 +93,9 @@ systemd-hwdb update
 %systemd_user_postun playserve.service gamescope-dbus.service
 
 %changelog
+* Fri Mar 21 2025 Luke Short <ekultails@gmail.com> 0.19.3-2
+- Fix FFmpeg dependency to be more generic
+
 * Fri Mar 21 2025 Alesh Slovak <aleshslovak@gmail.com> 0.19.3-1
 - Update version
 


### PR DESCRIPTION
for the latest 'playtron-os-files' RPM dependencies to install successfully.